### PR TITLE
feat: custom frameless window with platform controls

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,9 +6,30 @@
     <title>Conversation Viewer</title>
     <meta http-equiv="Content-Security-Policy" content="script-src 'self'"> 
     <style>
+        :root { --titlebar-height: 30px; }
         * { box-sizing: border-box; }
-        body, html { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 0; height: 100%; overflow: hidden; }
-        .container { display: flex; height: 100vh; }
+        html, body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 0; height: 100%; overflow: hidden; background: transparent; }
+        body { border-radius: 12px; overflow: hidden; background: #fff; }
+        #titlebar { height: var(--titlebar-height); -webkit-app-region: drag; display: flex; align-items: center; background: #f5f5f5; }
+        #window-controls { display: flex; gap: 8px; }
+        .window-button { -webkit-app-region: no-drag; padding: 0; border: none; background: transparent; width: 12px; height: 12px; border-radius: 50%; }
+        body.mac #titlebar { justify-content: flex-start; padding-left: 12px; }
+        body.mac .window-button.close { background: #ff5f57; }
+        body.mac .window-button.minimize { background: #ffbd2e; }
+        body.mac .window-button.maximize { background: #27c93f; }
+        body.windows #titlebar { justify-content: flex-end; }
+        body.windows .window-button { width: 45px; height: 100%; display: flex; align-items: center; justify-content: center; border-radius: 0; }
+        body.windows .window-button:hover { background: #e0e0e0; }
+        body.windows .window-button.close:hover { background: #ff5f57; color: #fff; }
+        body.windows .window-button::before { font-size: 12px; }
+        body.windows #close-btn::before { content: '\00D7'; }
+        body.windows #min-btn::before { content: '\2212'; }
+        body.windows #max-btn::before { content: '\25A1'; }
+        body.windows #max-btn.restore::before { content: '\2750'; }
+        body.windows #close-btn { order: 3; }
+        body.windows #min-btn { order: 1; }
+        body.windows #max-btn { order: 2; }
+        .container { display: flex; height: calc(100vh - var(--titlebar-height)); }
         #master-container { display: flex; flex-direction: column; width: 30%; border-right: 1px solid #ccc; }
         #detail-view { width: 70%; padding: 20px; overflow-y: auto; }
         #controls { padding: 15px; border-bottom: 1px solid #ccc; }
@@ -31,6 +52,13 @@
     </style>
 </head>
 <body>
+    <div id="titlebar">
+        <div id="window-controls">
+            <button class="window-button close" id="close-btn" aria-label="Close"></button>
+            <button class="window-button minimize" id="min-btn" aria-label="Minimize"></button>
+            <button class="window-button maximize" id="max-btn" aria-label="Maximize"></button>
+        </div>
+    </div>
     <div class="container">
         <div id="master-container">
             <div id="controls">

--- a/src/main.js
+++ b/src/main.js
@@ -8,11 +8,23 @@ function createWindow() {
     const win = new BrowserWindow({
         width: 1200,
         height: 800,
+        frame: false,
+        transparent: true,
+        titleBarStyle: 'hidden',
+        backgroundColor: '#00000000',
         webPreferences: {
             preload: path.join(__dirname, 'preload.js'),
             contextIsolation: true,
             nodeIntegration: false,
         },
+    });
+
+    win.on('maximize', () => {
+        win.webContents.send('window-state', 'maximized');
+    });
+
+    win.on('unmaximize', () => {
+        win.webContents.send('window-state', 'restored');
     });
 
     win.loadFile(path.join(__dirname, 'index.html'));
@@ -116,4 +128,23 @@ ipcMain.handle('extract-messages', (event, conversation) => {
         }
     }
     return pairedMessages;
+});
+
+ipcMain.on('window-control', (event, action) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    switch (action) {
+        case 'minimize':
+            win.minimize();
+            break;
+        case 'maximize':
+            if (win.isMaximized()) {
+                win.unmaximize();
+            } else {
+                win.maximize();
+            }
+            break;
+        case 'close':
+            win.close();
+            break;
+    }
 });

--- a/src/preload.js
+++ b/src/preload.js
@@ -3,5 +3,8 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electronAPI', {
     openZipFile: () => ipcRenderer.invoke('open-zip-file'),
-    extractMessages: (conversation) => ipcRenderer.invoke('extract-messages', conversation)
+    extractMessages: (conversation) => ipcRenderer.invoke('extract-messages', conversation),
+    windowControl: (action) => ipcRenderer.send('window-control', action),
+    platform: process.platform,
+    onWindowState: (callback) => ipcRenderer.on('window-state', (event, state) => callback(state))
 });

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -5,6 +5,24 @@ document.addEventListener('DOMContentLoaded', () => {
     const loadZipBtn = document.getElementById('load-zip-btn');
     const masterList = document.getElementById('master-list');
     const detailView = document.getElementById('detail-view');
+    const minBtn = document.getElementById('min-btn');
+    const maxBtn = document.getElementById('max-btn');
+    const closeBtn = document.getElementById('close-btn');
+
+    const platform = window.electronAPI.platform;
+    document.body.classList.add(platform === 'darwin' ? 'mac' : 'windows');
+
+    minBtn.addEventListener('click', () => window.electronAPI.windowControl('minimize'));
+    maxBtn.addEventListener('click', () => window.electronAPI.windowControl('maximize'));
+    closeBtn.addEventListener('click', () => window.electronAPI.windowControl('close'));
+
+    window.electronAPI.onWindowState((state) => {
+        if (state === 'maximized') {
+            maxBtn.classList.add('restore');
+        } else {
+            maxBtn.classList.remove('restore');
+        }
+    });
 
     let conversations = [];
 
@@ -27,7 +45,7 @@ document.addEventListener('DOMContentLoaded', () => {
             li.addEventListener('click', async (event) => {
                 document.querySelectorAll('#master-list li').forEach(item => item.classList.remove('selected'));
                 event.currentTarget.classList.add('selected');
-                
+
                 const selectedIndex = event.currentTarget.dataset.index;
                 const selectedConv = conversations[selectedIndex];
                 renderDetailView(selectedConv);


### PR DESCRIPTION
## Summary
- add frameless, transparent window with custom title bar and rounded corners
- expose window control APIs and platform info to renderer
- implement platform-specific window control buttons in UI

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae115933548330bb5da0f7ee88bba7